### PR TITLE
Fix issue #10: Advanced Search URL fixed

### DIFF
--- a/templates/partials/search.html.twig
+++ b/templates/partials/search.html.twig
@@ -6,6 +6,6 @@
 </div>
 {% if config.plugins.tntsearch.enabled %}
   <div class="adv-search">
-    <i class="fa fa-sliders"></i> <a href="{{ base_url_absolute }}/tntsearch">{{ 'THEME_LEARN2_ADVANCED_SEARCH'|t }}</a>
+    <i class="fa fa-sliders"></i> <a href="{{ base_url_absolute }}/search">{{ 'THEME_LEARN2_ADVANCED_SEARCH'|t }}</a>
   </div>
 {% endif %}


### PR DESCRIPTION
The template mistakenly directed to a wrong URL for the advanced fulltext search. With this commit, the issue is fixed.